### PR TITLE
Fix mobile layout overflow for custom ingredient input

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,6 +308,7 @@
     .custom-ingredient-input {
       display: flex;
       gap: 1rem;
+      flex-wrap: wrap;
     }
 
     .custom-ingredient-field {
@@ -830,10 +831,18 @@
       .mama-section {
         padding: 1.5rem;
       }
-      
+
       .search-btn {
         padding: 1.2rem 2.5rem;
         font-size: 1.1rem;
+      }
+
+      .custom-ingredient-input {
+        flex-direction: column;
+      }
+
+      .custom-ingredient-input .mama-button {
+        width: 100%;
       }
     }
 


### PR DESCRIPTION
## Summary
- wrap elements in the custom ingredient input area
- stack the input and button vertically on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a087d8f78832ea674cd0f47e6fe47