### PR TITLE
Fix custom ingredient input overflow on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -856,6 +856,10 @@
       .custom-ingredient-input .mama-button {
         width: 100%;
       }
+
+      .custom-ingredient-input .custom-ingredient-field {
+        width: 100%;
+      }
     }
 
     /* PDF Export Optimization */


### PR DESCRIPTION
## Summary
- adjust mobile styles so custom ingredient field spans full width

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684bc38e4168832e9be28590533eb8c3