### PR TITLE
Add inventory list and storage map modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -862,6 +862,57 @@
       }
     }
 
+    .modal-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0,0,0,0.5);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 2000;
+    }
+
+    .modal {
+      background: var(--surface);
+      padding: 2rem;
+      border-radius: var(--radius);
+      max-width: 600px;
+      width: 90%;
+      max-height: 80vh;
+      overflow-y: auto;
+    }
+
+    .modal h3 {
+      margin-top: 0;
+      margin-bottom: 1rem;
+      text-align: center;
+    }
+
+    .modal-close {
+      display: block;
+      margin: 1rem auto 0;
+    }
+
+    .map-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 1rem;
+    }
+
+    .map-cell {
+      background: var(--soft-green);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+
+    .map-cell h4 {
+      margin-bottom: 0.5rem;
+      font-size: 1rem;
+    }
+
     /* PDF Export Optimization */
     @media print {
       * {
@@ -933,6 +984,16 @@
           <div class="stat-icon">⏱️</div>
           <div class="stat-value" id="avg-time">0分</div>
           <div class="stat-label">平均調理時間</div>
+        </div>
+        <div class="stat-card" id="open-items">
+          <div class="stat-icon">📦</div>
+          <div class="stat-value">登録アイテム</div>
+          <div class="stat-label">一覧を見る</div>
+        </div>
+        <div class="stat-card" id="open-map">
+          <div class="stat-icon">🗺️</div>
+          <div class="stat-value">収納場所</div>
+          <div class="stat-label">マップで確認</div>
         </div>
       </div>
 
@@ -1060,6 +1121,23 @@
         </div>
       </section>
     </div>
+
+    <div id="items-modal" class="modal-overlay">
+      <div class="modal">
+        <h3>登録アイテム一覧</h3>
+        <ul id="item-list"></ul>
+        <button class="mama-button btn-primary modal-close" id="close-items">閉じる</button>
+      </div>
+    </div>
+
+    <div id="map-modal" class="modal-overlay">
+      <div class="modal">
+        <h3>収納マップ</h3>
+        <div id="storage-map" class="map-grid"></div>
+        <button class="mama-button btn-primary modal-close" id="close-map">閉じる</button>
+      </div>
+    </div>
+
   </main>
 
   <footer class="footer">
@@ -1338,6 +1416,7 @@ const mamaRecipesData = {
 let selectedIngredients = new Set();
 let currentRecipes = [];
 let favorites = new Set();
+let inventory = [];
 
 // DOM Elements
 const ingredientsDiv = document.getElementById('ingredients');
@@ -1356,16 +1435,98 @@ const selectedCountEl = document.getElementById('selected-count');
 const recipeCountEl = document.getElementById('recipe-count');
 const matchRateEl = document.getElementById('match-rate');
 const avgTimeEl = document.getElementById('avg-time');
+const itemsModal = document.getElementById('items-modal');
+const mapModal = document.getElementById('map-modal');
+const itemListEl = document.getElementById('item-list');
+const storageMapEl = document.getElementById('storage-map');
+
+function loadInventory() {
+  try {
+    const saved = localStorage.getItem('mama-inventory');
+    if (saved) {
+      inventory = JSON.parse(saved);
+    }
+  } catch (e) {
+    console.log('Cannot load inventory:', e);
+    inventory = [];
+  }
+}
+
+function saveInventory() {
+  try {
+    localStorage.setItem('mama-inventory', JSON.stringify(inventory));
+  } catch (e) {
+    console.log('Cannot save inventory:', e);
+  }
+}
+
+function addInventoryItem(name, location) {
+  inventory.push({ name, location });
+  saveInventory();
+}
+
+function renderItemList() {
+  if (inventory.length === 0) {
+    itemListEl.innerHTML = '<li>アイテムが登録されていません</li>';
+    return;
+  }
+  itemListEl.innerHTML = inventory.map(item => `<li>${item.name} - ${item.location}</li>`).join('');
+}
+
+function renderStorageMap() {
+  if (inventory.length === 0) {
+    storageMapEl.innerHTML = '<p>アイテムが登録されていません</p>';
+    return;
+  }
+  const groups = {};
+  inventory.forEach(item => {
+    const loc = item.location || '未設定';
+    if (!groups[loc]) groups[loc] = [];
+    groups[loc].push(item.name);
+  });
+  storageMapEl.innerHTML = Object.entries(groups).map(([loc, items]) => `
+      <div class="map-cell">
+        <h4>${loc}</h4>
+        <ul>${items.map(n => `<li>${n}</li>`).join('')}</ul>
+      </div>
+  `).join('');
+}
+
+function showItems() {
+  renderItemList();
+  itemsModal.style.display = 'flex';
+}
+
+function showMap() {
+  renderStorageMap();
+  mapModal.style.display = 'flex';
+}
+
+function closeItems() {
+  itemsModal.style.display = 'none';
+}
+
+function closeMap() {
+  mapModal.style.display = 'none';
+}
 
 // Initialize the app
 function init() {
   renderIngredients();
   loadFavorites();
+  loadInventory();
   updateStats();
   
   // Set default filters for busy moms
   timeFilter.value = '15';
   difficultyFilter.value = 'easy';
+
+  document.getElementById('open-items').addEventListener('click', showItems);
+  document.getElementById('close-items').addEventListener('click', closeItems);
+  document.getElementById('open-map').addEventListener('click', showMap);
+  document.getElementById('close-map').addEventListener('click', closeMap);
+  itemsModal.addEventListener('click', e => { if (e.target === itemsModal) closeItems(); });
+  mapModal.addEventListener('click', e => { if (e.target === mapModal) closeMap(); });
 }
 
 // Render ingredient cards with emojis
@@ -1408,6 +1569,11 @@ function renderIngredients() {
 function toggleIngredient(ingredient, isSelected) {
   if (isSelected) {
     selectedIngredients.add(ingredient);
+    const exists = inventory.find(item => item.name === ingredient);
+    if (!exists) {
+      const loc = prompt('収納場所を入力してください (例: 冷蔵庫上段)') || '未設定';
+      addInventoryItem(ingredient, loc);
+    }
   } else {
     selectedIngredients.delete(ingredient);
   }
@@ -1425,6 +1591,9 @@ function addCustomIngredient() {
   }
   
   selectedIngredients.add(ingredient);
+
+  const location = prompt('収納場所を入力してください (例: 冷蔵庫上段)') || '未設定';
+  addInventoryItem(ingredient, location);
   
   // Add to UI
   const card = document.createElement('div');


### PR DESCRIPTION
## Summary
- show '登録アイテム' and '収納場所' cards in stats area
- add modal overlays for item list and storage map
- implement inventory management with localStorage
- prompt user for storage location when adding an item

## Testing
- `node -e "require('fs').readFileSync('index.html'); console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_684bc4fbb460832e96f65e167a66ee1b