### PR TITLE
Fix mobile stats box sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -830,10 +830,27 @@
         padding: 0.75rem 1rem;
         font-size: 0.8rem;
       }
-      
+
       .ingredients-grid {
         grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
         gap: 0.75rem;
+      }
+
+      .quick-stats {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 1rem;
+      }
+
+      .stat-card {
+        padding: 1rem;
+      }
+
+      .stat-icon {
+        font-size: 2rem;
+      }
+
+      .stat-value {
+        font-size: 2rem;
       }
       
       .recipe-grid {


### PR DESCRIPTION
## Summary
- adjust quick stats layout for mobile view
- shrink stat card dimensions and fonts for small screens

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/pantry-chef/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_684bccbe9fe4832ea9f5b3aaad12cd65