### PR TITLE
Fix mobile recipe card overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -957,6 +957,10 @@
 
     .recipe-card .recipe-header {
       padding-bottom: 3rem; padding-right: 3rem;}
+
+    .recipe-title {
+      margin-right: 6rem;
+    }
   }
 
   @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- add margin to recipe title on narrow screens to avoid overlapping with the time badge

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ccf2fd0e8832e9139b9ead047ade0