### PR TITLE
Add auto-open for ingredients accordion

### DIFF
--- a/index.html
+++ b/index.html
@@ -1357,6 +1357,12 @@ function initStatsScroll() {
         const target = document.querySelector(selector);
         if (target) {
           target.scrollIntoView({ behavior: 'smooth' });
+          if (selector === '#ingredients-section') {
+            const header = target.querySelector('.section-header.accordion-header');
+            if (header && target.classList.contains('collapsed')) {
+              setTimeout(() => header.click(), 300);
+            }
+          }
         }
       });
     });


### PR DESCRIPTION
## Summary
- open the "冷蔵庫の食材をチェック" accordion when tapping the stats card

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684cef3b9754832e912a464fd736392d