### PR TITLE
Fix caching error in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -13,11 +13,21 @@ const urlsToCache = [
 ];
 
 self.addEventListener("install", event => {
-  event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(urlsToCache))
-      .catch(err => console.error("Cache addAll failed:", err))
-  );
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_NAME);
+    for (const url of urlsToCache) {
+      try {
+        const response = await fetch(url, { cache: 'reload' });
+        if (response.ok) {
+          await cache.put(url, response.clone());
+        } else {
+          console.warn('Skip caching:', url, response.status);
+        }
+      } catch (err) {
+        console.warn('Failed to fetch', url, err);
+      }
+    }
+  })());
 });
 
 self.addEventListener("fetch", event => {


### PR DESCRIPTION
## Summary
- handle failures during service worker installation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684de3a6c338832ea76d25696311f93d