### PR TITLE
Add searchable recipe list page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1110,11 +1110,11 @@
           <div class="stat-value" id="recipe-count">0</div>
           <div class="stat-label">見つかったレシピ</div>
         </div>
-        <div class="stat-card">
+        <a href="recipes.html" class="stat-card block">
           <div class="stat-icon">🍳</div>
           <div class="stat-value" id="total-recipe-count">0</div>
           <div class="stat-label">総レシピ数</div>
-        </div>
+        </a>
       </div>
 
       <!-- Ingredients Selection Section -->

--- a/js/recipe-list.js
+++ b/js/recipe-list.js
@@ -1,0 +1,34 @@
+function renderRecipes() {
+  const listEl = document.getElementById('recipe-list');
+  const search = document.getElementById('recipe-search').value.trim();
+  const sort = document.getElementById('recipe-sort').value;
+
+  let list = recipesData.recipes.slice();
+  if (search) {
+    list = list.filter(r => r.name.includes(search) || r.ingredients.some(i => i.includes(search)));
+  }
+  if (sort === 'name') {
+    list.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+  } else if (sort === 'time-asc') {
+    list.sort((a, b) => a.cookingTime - b.cookingTime);
+  } else if (sort === 'time-desc') {
+    list.sort((a, b) => b.cookingTime - a.cookingTime);
+  }
+
+  document.getElementById('total-count').textContent = `総レシピ数: ${list.length}`;
+
+  listEl.innerHTML = '';
+  list.forEach(r => {
+    const div = document.createElement('div');
+    div.className = 'border bg-white p-2 rounded';
+    const link = r.source ? `<a href="${r.source}" class="text-blue-600 underline" target="_blank" rel="noopener">${r.name}</a>` : r.name;
+    div.innerHTML = `${link} <span class="text-sm text-gray-600">(${r.cookingTime}分)</span>`;
+    listEl.appendChild(div);
+  });
+}
+
+document.getElementById('recipe-search').addEventListener('input', renderRecipes);
+document.getElementById('recipe-sort').addEventListener('change', renderRecipes);
+
+// 初期表示
+renderRecipes();

--- a/recipes.html
+++ b/recipes.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>レシピ一覧</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50 text-gray-800">
+  <main class="max-w-2xl mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">レシピ一覧</h1>
+    <div class="mb-4 flex flex-col sm:flex-row sm:items-center sm:space-x-2 space-y-2 sm:space-y-0">
+      <input id="recipe-search" type="text" placeholder="検索" class="flex-1 border border-gray-300 p-2 rounded" />
+      <select id="recipe-sort" class="border border-gray-300 p-2 rounded">
+        <option value="name">名前順</option>
+        <option value="time-asc">調理時間が短い順</option>
+        <option value="time-desc">調理時間が長い順</option>
+      </select>
+    </div>
+    <p class="mb-2" id="total-count"></p>
+    <div id="recipe-list" class="space-y-2"></div>
+    <a href="index.html" class="text-blue-600 underline block mt-4">トップページへ戻る</a>
+  </main>
+  <script src="js/recipes.js"></script>
+  <script src="js/recipe-list.js"></script>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -5,11 +5,13 @@ const urlsToCache = [
   'css/style.css',
   'js/app.js',
   'js/recipes.js',
+  'js/recipe-list.js',
   'js/affiliates.js',
   'data/recipes.json',
   'images/icon-192x192.png',
   'images/icon-512x512.png',
-  'images/ogp-image.jpg'
+  'images/ogp-image.jpg',
+  'recipes.html'
 ];
 
 self.addEventListener("install", event => {


### PR DESCRIPTION
## Summary
- make total recipe count link to new page
- provide a recipe list page with search and sort
- cache new files in service worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dec5d0648832ea01516e69a24c110