### PR TITLE
UI adjustments for checkbox reset and accordion defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -1143,7 +1143,7 @@
       </div>
 
       <!-- Ingredients Selection Section -->
-      <section id="ingredients-section" class="mama-section collapsed">
+      <section id="ingredients-section" class="mama-section">
         <div class="section-header accordion-header" onclick="toggleSection(event)">
           <div class="section-icon">
             <i class="fas fa-carrot"></i>
@@ -1152,13 +1152,18 @@
             <h2 class="section-title">冷蔵庫の食材をチェック</h2>
             <p class="section-subtitle">今ある食材を選んで、無駄なく美味しく！</p>
           </div>
-            <span class="accordion-arrow"><i class="fas fa-chevron-down"></i></span>
+            <span class="accordion-arrow"><i class="fas fa-chevron-up"></i></span>
         </div>
 
-        <div class="accordion-content">
+        <div class="accordion-content" style="display:block;">
           <div class="ingredients-container">
             <div class="ingredient-search">
               <input type="text" id="ingredient-search" placeholder="食材を検索...">
+            </div>
+            <div class="clear-ingredients">
+              <button class="mama-button btn-secondary" id="clear-ingredients">
+                <i class="fas fa-undo"></i> 全てのチェックを外す
+              </button>
             </div>
             <div class="ingredients-grid" id="ingredients"></div>
           </div>
@@ -1172,11 +1177,6 @@
               <input type="text" id="custom-ingredient" class="custom-ingredient-field" placeholder="例：きゅうり、しいたけ、豆腐...">
               <button class="mama-button btn-secondary" id="add-ingredient">
                 <i class="fas fa-plus"></i> 追加
-              </button>
-            </div>
-            <div class="clear-ingredients">
-              <button class="mama-button btn-secondary" id="clear-ingredients">
-                <i class="fas fa-undo"></i> 全てのチェックを外す
               </button>
             </div>
           </div>
@@ -1219,7 +1219,7 @@
       </section>
 
       <!-- Search Filters Section -->
-      <section class="mama-section collapsed">
+      <section class="mama-section">
         <div class="section-header accordion-header" onclick="toggleSection(event)">
           <div class="section-icon">
             <i class="fas fa-filter"></i>
@@ -1228,10 +1228,10 @@
             <h2 class="section-title">お好みの条件を設定</h2>
             <p class="section-subtitle">忙しい日でも安心！時短レシピを優先検索</p>
           </div>
-          <span class="accordion-arrow"><i class="fas fa-chevron-down"></i></span>
+          <span class="accordion-arrow"><i class="fas fa-chevron-up"></i></span>
         </div>
 
-        <div class="accordion-content">
+        <div class="accordion-content" style="display:block;">
           <div class="filters-section">
             <div class="filters-grid">
             <div class="filter-group">


### PR DESCRIPTION
## Summary
- reposition the "全てのチェックを外す" button below the ingredient search box
- show 食材 and お好みの条件 sections expanded by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684df9dd1ac8832eab6296ba360d4609