### PR TITLE
Add weekly menu planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -1140,6 +1140,11 @@
           <div class="stat-value" id="total-recipe-count">0</div>
           <div class="stat-label">総レシピ数</div>
         </a>
+        <a href="weekly.html" class="stat-card block">
+          <div class="stat-icon">📅</div>
+          <div class="stat-value">7</div>
+          <div class="stat-label">週間献立</div>
+        </a>
       </div>
 
       <!-- Ingredients Selection Section -->

--- a/js/weekly.js
+++ b/js/weekly.js
@@ -1,0 +1,60 @@
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+const seasonalIngredients = {
+  1: ['白菜', '大根', '長ねぎ', 'ほうれん草'],
+  2: ['菜の花', 'ほうれん草', '大根'],
+  3: ['キャベツ', '新玉ねぎ', 'いちご'],
+  4: ['筍', 'アスパラガス', 'キャベツ'],
+  5: ['新じゃがいも', 'アスパラガス', 'レタス'],
+  6: ['きゅうり', 'トマト', 'ズッキーニ'],
+  7: ['なす', 'ピーマン', 'オクラ'],
+  8: ['なす', 'トマト', 'とうもろこし'],
+  9: ['さつまいも', 'きのこ類', 'さんま'],
+ 10: ['さつまいも', 'きのこ類', 'かぼちゃ'],
+ 11: ['白菜', '大根', 'ほうれん草'],
+ 12: ['白菜', '長ねぎ', '大根']
+};
+
+function pickRecipe(list, seasonIngs) {
+  const candidates = list.filter(r => r.ingredients.some(i => seasonIngs.includes(i)));
+  const chosenList = candidates.length ? candidates : list;
+  return chosenList[Math.floor(Math.random() * chosenList.length)];
+}
+
+function generateWeeklyMenu() {
+  const month = new Date().getMonth() + 1;
+  const seasonIngs = seasonalIngredients[month] || [];
+  const mains = recipesData.recipes.filter(r => r.category === 'main');
+  const sides = recipesData.recipes.filter(r => r.category === 'side');
+  const soups = recipesData.recipes.filter(r => r.category === 'soup');
+
+  shuffle(mains);
+  shuffle(sides);
+  shuffle(soups);
+
+  const menuDiv = document.getElementById('menu');
+  menuDiv.innerHTML = '';
+  const days = ['月','火','水','木','金','土','日'];
+  for (let i = 0; i < 7; i++) {
+    const main = pickRecipe(mains, seasonIngs);
+    const side = pickRecipe(sides, seasonIngs);
+    const soup = pickRecipe(soups, seasonIngs);
+
+    const card = document.createElement('div');
+    card.className = 'border bg-white p-2 rounded';
+    card.innerHTML = `
+      <div class="font-bold">${days[i]}曜日</div>
+      <div>メイン: ${main.name}</div>
+      <div>副菜: ${side.name}</div>
+      <div>スープ: ${soup.name}</div>
+    `;
+    menuDiv.appendChild(card);
+  }
+}
+
+document.getElementById('gen-btn').addEventListener('click', generateWeeklyMenu);

--- a/weekly.html
+++ b/weekly.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>週間献立</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <h1 class="text-xl">週間献立提案</h1>
+    <a href="index.html" class="text-blue-600 underline">トップへ戻る</a>
+  </header>
+  <main class="max-w-2xl mx-auto p-4">
+    <button id="gen-btn" class="mama-button btn-primary mb-4" style="padding:0.5rem 1rem;background:var(--primary-color);color:white;border-radius:8px;">献立を生成</button>
+    <div id="menu" class="space-y-4"></div>
+  </main>
+  <script src="js/recipes.js"></script>
+  <script src="js/weekly.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- propose weekly menus with a new planner page
- link to the new feature from the quick stats area

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684dfbfae534832e985fc8dbe4c68024