### PR TITLE
デザイン: 買い物リストをトップページに合わせる

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -199,3 +199,46 @@ footer {
 .week-card .recipe-header {
   padding: 1rem 1.5rem;
 }
+
+/* Shopping list styles matching the top page */
+.ingredients-section {
+  margin-bottom: 2rem;
+}
+
+.ingredients-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ingredients-list {
+  list-style: none;
+  background: var(--background);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.ingredient-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.ingredient-item:last-child {
+  border-bottom: none;
+}
+
+.ingredient-available {
+  color: var(--primary-color);
+  font-weight: 600;
+}
+
+.ingredient-missing {
+  color: var(--text-secondary);
+}

--- a/js/shopping.js
+++ b/js/shopping.js
@@ -14,8 +14,10 @@ window.addEventListener('DOMContentLoaded', () => {
       return;
     }
     const ul = document.createElement('ul');
+    ul.className = 'ingredients-list';
     items.forEach(i => {
       const li = document.createElement('li');
+      li.className = 'ingredient-item';
       li.textContent = i;
       ul.appendChild(li);
     });

--- a/shopping.html
+++ b/shopping.html
@@ -21,7 +21,7 @@
     </div>
   </header>
   <main class="main-container py-8">
-    <div id="shopping-items" class="mb-4"></div>
+    <div id="shopping-items" class="ingredients-section mb-4"></div>
     <button id="clear-list" class="mama-button btn-secondary">リストをクリア</button>
   </main>
   <script src="js/shopping.js"></script>


### PR DESCRIPTION
## Summary
- unify shopping list styles with main page
- create `.ingredients-*` styles in CSS
- apply the new classes in `shopping.html` and script

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e2c6a8720832ea9b6cf5b597ea15f